### PR TITLE
Refactored instanceof usage to isKind() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "build:cjs": "tsc --declaration --declarationMap --declarationDir dist/types ",
     "build:umd": "rollup --config config/rollup.config.js",
     "build:umd:min": "cd dist && uglifyjs --compress --mangle --source-map --comments --output standalone.min.js -- standalone.js",
+    "watch": "tsc -w  --declaration --declarationMap --declarationDir dist/types",
     "clean": "shx rm -rf dist",
     "docs": "typedoc --theme minimal --exclude \"**/src/**/__tests__/*.*\" --out docs src/",
     "test": "jest -c ./config/jest.config.js --passWithNoTests",

--- a/src/ast/definitions.ts
+++ b/src/ast/definitions.ts
@@ -8,6 +8,7 @@ import { kinds } from "./kinds";
 export interface Definition {
   getKind(): string;
   getLoc(): Location | undefined;
+  isKind(node: any): boolean;
 }
 
 export class AnnotationDefinition extends AbstractNode implements Definition {

--- a/src/ast/node.ts
+++ b/src/ast/node.ts
@@ -5,6 +5,7 @@ export interface Node {
   getKind(): string;
   getLoc(): Location | undefined;
   accept(_context: Context, _visitor: Visitor): void;
+  isKind(node: any): boolean;
 }
 
 export type NodeArray = Node[];
@@ -24,6 +25,11 @@ export abstract class AbstractNode implements Node {
 
   public getLoc(): Location | undefined {
     return this.loc;
+  }
+
+  public isKind(node: any): boolean {
+    if (node === undefined && node === null) return false;
+    return node.name === this.kind;
   }
 
   public accept(_context: Context, _visitor: Visitor): void {}

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -7,6 +7,7 @@ export interface Type {
   getKind(): string;
   getLoc(): Location | undefined;
   string(): string;
+  isKind(node: any): boolean;
 }
 
 export class Named extends AbstractNode implements Type {

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -7,6 +7,7 @@ export interface Value {
   getValue(): any; //interface{}
   getKind(): string;
   getLoc(): Location | undefined;
+  isKind(node: any): boolean;
 }
 
 export class Variable extends AbstractNode implements Value {


### PR DESCRIPTION
`a instanceof B` in JavaScript only returns true if `a` is an instance of the specific object referenced by `B`. If there are multiple, identical `B`s from different files or in different execution contexts then `instanceof` will return false. I saw this problem when developing with a local `widl-codegen-js` and `widl-js` from npm.

Since `widl-js` (and `widl-codegen-js`) doesn't need that behavior, I added an `isKind` method that tests against the `.kind` property of AST nodes.