### PR TITLE
Alias types

### DIFF
--- a/src/ast/definitions.ts
+++ b/src/ast/definitions.ts
@@ -33,14 +33,14 @@ export interface TypeSystemDefinition {
 }
 
 export class NamespaceDefinition extends AbstractNode {
-  description?: StringValue;
   name: Name;
+  description?: StringValue;
   annotations: Annotation[];
 
   constructor(
     loc: Location | undefined,
-    desc: StringValue | undefined,
     name: Name,
+    desc: StringValue | undefined,
     annotations?: Annotation[]
   ) {
     super(Kind.NamespaceDefinition, loc);
@@ -58,6 +58,39 @@ export class NamespaceDefinition extends AbstractNode {
 
   public accept(context: Context, visitor: Visitor): void {
     visitor.visitNamespace(context);
+    visitAnnotations(context, visitor, this.annotations);
+  }
+}
+
+export class AliasDefinition extends AbstractNode {
+  name: Name;
+  description?: StringValue;
+  type: Type;
+  annotations: Annotation[];
+
+  constructor(
+    loc: Location | undefined,
+    name: Name,
+    desc: StringValue | undefined,
+    type: Type,
+    annotations?: Annotation[]
+  ) {
+    super(Kind.AliasDefinition, loc);
+    this.name = name;
+    this.description = desc;
+    this.type = type;
+    this.annotations = annotations || [];
+  }
+
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined {
+    return getAnnotation(name, this.annotations, callback);
+  }
+
+  public accept(context: Context, visitor: Visitor): void {
+    visitor.visitAlias(context);
     visitAnnotations(context, visitor, this.annotations);
   }
 }

--- a/src/ast/document.ts
+++ b/src/ast/document.ts
@@ -30,6 +30,12 @@ export class Document extends AbstractNode {
     });
     visitor.visitDirectivesAfter(context);
 
+    visitor.visitAliasesBefore(context);
+    context.aliases.map((alias) => {
+      alias.accept(context.clone({ alias: alias }), visitor);
+    });
+    visitor.visitAliasesAfter(context);
+
     visitor.visitAllOperationsBefore(context);
     context.interface.accept(context, visitor);
 

--- a/src/ast/kinds.ts
+++ b/src/ast/kinds.ts
@@ -27,6 +27,7 @@ export enum Kind {
   // Definitions
   NamespaceDefinition = "NamespaceDefinition",
   ImportDefinition = "ImportDefinition",
+  AliasDefinition = "AliasDefinition",
   InterfaceDefinition = "InterfaceDefinition",
   RoleDefinition = "RoleDefinition",
   OperationDefinition = "OperationDefinition",

--- a/src/rules/known_types.ts
+++ b/src/rules/known_types.ts
@@ -29,8 +29,9 @@ const builtInTypeNames = new Set([
 ]);
 
 export class KnownTypes extends AbstractVisitor {
-  visitOperationBefore(context: Context): void {
-    const oper = context.operation!;
+  visitAlias(context: Context): void {
+    const alias = context.alias!;
+    this.checkType(context, `alias`, alias.name.value, alias.type);
   }
   visitOperationAfter(context: Context): void {
     const oper = context.operation!;

--- a/src/rules/pascal_case_type_names.ts
+++ b/src/rules/pascal_case_type_names.ts
@@ -4,12 +4,42 @@ import { validationError } from "../error";
 const pascalMatcher = /[A-Z][0-9A-Za-z]/;
 
 export class PascalCaseTypeNames extends AbstractVisitor {
+  visitAlias(context: Context): void {
+    const alias = context.alias!;
+    const name = alias.name.value;
+    if (!pascalMatcher.test(name)) {
+      context.reportError(
+        validationError(alias.name, `alias "${name}" should be pascal case`)
+      );
+    }
+  }
+
   visitType(context: Context): void {
     const type = context.type!;
     const name = type.name.value;
     if (!pascalMatcher.test(name)) {
       context.reportError(
         validationError(type.name, `type "${name}" should be pascal case`)
+      );
+    }
+  }
+
+  visitEnum(context: Context): void {
+    const enumDef = context.enum!;
+    const name = enumDef.name.value;
+    if (!pascalMatcher.test(name)) {
+      context.reportError(
+        validationError(enumDef.name, `enum "${name}" should be pascal case`)
+      );
+    }
+  }
+
+  visitUnion(context: Context): void {
+    const union = context.union!;
+    const name = union.name.value;
+    if (!pascalMatcher.test(name)) {
+      context.reportError(
+        validationError(union.name, `union "${name}" should be pascal case`)
       );
     }
   }

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -1,5 +1,5 @@
 import { Visitor } from "../ast";
-import { CamelCaseDirectiveNames } from "./camel_case_directive_names";
+//import { CamelCaseDirectiveNames } from "./camel_case_directive_names";
 import { PascalCaseTypeNames } from "./pascal_case_type_names";
 import { UniqueDirectiveNames } from "./unique_directive_names";
 import { UniqueObjectNames } from "./unique_object_names";
@@ -8,7 +8,7 @@ import { UniqueParameterNames } from "./unique_parameter_names";
 import { UniqueTypeFieldNames } from "./unique_type_field_names";
 import { UniqueEnumValueNames } from "./unique_enum_value_names";
 import { UniqueEnumValueIndexes } from "./unique_enum_value_indexes";
-import { PositiveEnumValueIndexes } from "./positive_enum_value_indexes";
+import { ValidEnumValueIndexes } from "./valid_enum_value_indexes";
 import { KnownTypes } from "./known_types";
 import { ValidDirectiveParameterTypes } from "./valid_directive_parameter_types";
 import { ValidDirectiveRequires } from "./valid_directive_requires";
@@ -30,7 +30,7 @@ export const CommonRules: Array<ValidationRule> = [
   UniqueTypeFieldNames,
   UniqueEnumValueNames,
   UniqueEnumValueIndexes,
-  PositiveEnumValueIndexes,
+  ValidEnumValueIndexes,
   KnownTypes,
   ValidDirectiveParameterTypes,
   ValidDirectiveRequires,

--- a/src/rules/valid_enum_value_indexes.ts
+++ b/src/rules/valid_enum_value_indexes.ts
@@ -1,7 +1,7 @@
 import { AbstractVisitor, Context } from "../ast";
 import { validationError } from "../error";
 
-export class PositiveEnumValueIndexes extends AbstractVisitor {
+export class ValidEnumValueIndexes extends AbstractVisitor {
   private parentName: string = "";
 
   visitEnum(context: Context): void {
@@ -10,11 +10,11 @@ export class PositiveEnumValueIndexes extends AbstractVisitor {
   visitEnumValue(context: Context): void {
     const enumValue = context.enumValue!;
     const value = enumValue.index.value;
-    if (isNaN(value) || value < 1) {
+    if (isNaN(value) || value < 0) {
       context.reportError(
         validationError(
           enumValue.index,
-          `value index "${enumValue.index.value}" in enum "${this.parentName}" must be a positive integer`
+          `value index "${enumValue.index.value}" in enum "${this.parentName}" must be a non-negative integer`
         )
       );
     }


### PR DESCRIPTION
Alias syntax:
```
alias UUID = bytes
```

Aliases are similar to (and inspired by) [Scalar types from GraphQL](https://graphql.org/learn/schema/), but the difference is that Aliases target a primitive _or_ user-defined type. The intention is mainly to help the a code generation module redirect an aliased type to an alternate type that is treated a specific way. For example, the alias of `UUID = bytes` might indicate that a byte array that should be treated as a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier) (16 bytes). The code generator would select the ideal internal type for its targeted programming language.

Minor fix: Allow for zero as enum values.