### PR TITLE
Validation rules (Single namespace and interface definitions, Directives on aliases), Enum value display fix, Annotated interface

### DIFF
--- a/src/ast/definitions.ts
+++ b/src/ast/definitions.ts
@@ -17,6 +17,13 @@ export interface Definition {
   getLoc(): Location | undefined;
 }
 
+export interface Annotated {
+  annotation(
+    name: string,
+    callback?: (annotation: Annotation) => void
+  ): Annotation | undefined;
+}
+
 // DescribableNode are nodes that have descriptions associated with them.
 export interface DescribableNode {
   getDescription(): StringValue;
@@ -32,7 +39,7 @@ export interface TypeSystemDefinition {
   getLoc(): Location;
 }
 
-export class NamespaceDefinition extends AbstractNode {
+export class NamespaceDefinition extends AbstractNode implements Annotated {
   name: Name;
   description?: StringValue;
   annotations: Annotation[];
@@ -62,7 +69,7 @@ export class NamespaceDefinition extends AbstractNode {
   }
 }
 
-export class AliasDefinition extends AbstractNode {
+export class AliasDefinition extends AbstractNode implements Annotated {
   name: Name;
   description?: StringValue;
   type: Type;
@@ -95,7 +102,7 @@ export class AliasDefinition extends AbstractNode {
   }
 }
 
-export class ImportDefinition extends AbstractNode {
+export class ImportDefinition extends AbstractNode implements Annotated {
   description?: StringValue;
   all: boolean;
   names: ImportName[];
@@ -131,7 +138,7 @@ export class ImportDefinition extends AbstractNode {
   }
 }
 
-export class TypeDefinition extends AbstractNode {
+export class TypeDefinition extends AbstractNode implements Annotated {
   name: Name;
   description?: StringValue;
   interfaces: Named[];
@@ -177,7 +184,7 @@ export class TypeDefinition extends AbstractNode {
   }
 }
 
-export class OperationDefinition extends AbstractNode {
+export class OperationDefinition extends AbstractNode implements Annotated {
   name: Name;
   description: StringValue | undefined;
   parameters: ParameterDefinition[];
@@ -251,7 +258,9 @@ export class OperationDefinition extends AbstractNode {
   }
 }
 
-export abstract class ValuedDefinition extends AbstractNode {
+export abstract class ValuedDefinition
+  extends AbstractNode
+  implements Annotated {
   name: Name;
   description?: StringValue;
   type: Type;
@@ -331,7 +340,9 @@ export class ParameterDefinition extends ValuedDefinition {
   }
 }
 
-export class InterfaceDefinition extends AbstractNode implements Definition {
+export class InterfaceDefinition
+  extends AbstractNode
+  implements Definition, Annotated {
   description?: StringValue;
   operations: OperationDefinition[];
   annotations: Annotation[];
@@ -371,7 +382,9 @@ export class InterfaceDefinition extends AbstractNode implements Definition {
   }
 }
 
-export class RoleDefinition extends AbstractNode implements Definition {
+export class RoleDefinition
+  extends AbstractNode
+  implements Definition, Annotated {
   name: Name;
   description?: StringValue;
   operations: OperationDefinition[];
@@ -414,7 +427,9 @@ export class RoleDefinition extends AbstractNode implements Definition {
   }
 }
 
-export class UnionDefinition extends AbstractNode implements Definition {
+export class UnionDefinition
+  extends AbstractNode
+  implements Definition, Annotated {
   name: Name;
   description?: StringValue;
   annotations: Annotation[];
@@ -447,7 +462,9 @@ export class UnionDefinition extends AbstractNode implements Definition {
   }
 }
 
-export class EnumDefinition extends AbstractNode implements Definition {
+export class EnumDefinition
+  extends AbstractNode
+  implements Definition, Annotated {
   name: Name;
   description?: StringValue;
   annotations: Annotation[];
@@ -475,6 +492,7 @@ export class EnumDefinition extends AbstractNode implements Definition {
   }
 
   public accept(context: Context, visitor: Visitor): void {
+    visitor.visitEnumBefore(context);
     visitor.visitEnum(context);
 
     context = context.clone({ enumValues: context.enum!.values });
@@ -485,10 +503,13 @@ export class EnumDefinition extends AbstractNode implements Definition {
     visitor.visitEnumValuesAfter(context);
 
     visitAnnotations(context, visitor, this.annotations);
+    visitor.visitEnumAfter(context);
   }
 }
 
-export class EnumValueDefinition extends AbstractNode implements Definition {
+export class EnumValueDefinition
+  extends AbstractNode
+  implements Definition, Annotated {
   name: Name;
   description?: StringValue;
   annotations: Annotation[];

--- a/src/ast/definitions.ts
+++ b/src/ast/definitions.ts
@@ -359,7 +359,7 @@ export class InterfaceDefinition extends AbstractNode implements Definition {
     visitor.visitInterfaceBefore(context);
     visitor.visitInterface(context);
 
-    context = context.clone({ operations: context.interface.operations });
+    context = context.clone({ operations: context.interface!.operations });
     visitor.visitOperationsBefore(context);
     context.operations!.map((operation) => {
       operation.accept(context.clone({ operation: operation }), visitor);

--- a/src/ast/document.ts
+++ b/src/ast/document.ts
@@ -16,7 +16,9 @@ export class Document extends AbstractNode {
     context = new Context(context.config, this, context);
     visitor.visitDocumentBefore(context);
 
-    context.namespace.accept(context, visitor);
+    context.namespaces.map((namespace) => {
+      namespace.accept(context.clone({ namespace: namespace }), visitor);
+    });
 
     visitor.visitImportsBefore(context);
     context.imports.map((importDef) => {
@@ -37,7 +39,9 @@ export class Document extends AbstractNode {
     visitor.visitAliasesAfter(context);
 
     visitor.visitAllOperationsBefore(context);
-    context.interface.accept(context, visitor);
+    context.interfaces.map((iface) => {
+      iface.accept(context.clone({ interfaceDef: iface }), visitor);
+    });
 
     visitor.visitRolesBefore(context);
     context.roles.map((role) => {

--- a/src/ast/visitor.ts
+++ b/src/ast/visitor.ts
@@ -34,9 +34,11 @@ export class Writer {
 export type ObjectMap<T = any> = { [key: string]: T };
 
 interface NamedParameters {
+  namespace?: NamespaceDefinition;
   importDef?: ImportDefinition;
   directive?: DirectiveDefinition;
   alias?: AliasDefinition;
+  interfaceDef?: InterfaceDefinition;
   role?: RoleDefinition;
   type?: TypeDefinition;
   operations?: OperationDefinition[];
@@ -71,12 +73,12 @@ export class Context {
   document?: Document;
 
   // Top-level definitions
-  namespace: NamespaceDefinition;
+  namespaces: NamespaceDefinition[];
   imports: ImportDefinition[];
   directives: DirectiveDefinition[];
   directiveMap: Map<string, DirectiveDefinition>;
   aliases: AliasDefinition[];
-  interface: InterfaceDefinition;
+  interfaces: InterfaceDefinition[];
   roles: RoleDefinition[];
   types: TypeDefinition[];
   enums: EnumDefinition[];
@@ -87,9 +89,12 @@ export class Context {
   >;
 
   // Drill-down definitions
-  importDef?: ImportDefinition;
+  namespace: NamespaceDefinition;
+  namespacePos: number = 9999;
+  import?: ImportDefinition;
   directive?: DirectiveDefinition;
   alias?: AliasDefinition;
+  interface?: InterfaceDefinition;
   role?: RoleDefinition;
   type?: TypeDefinition;
   operations?: OperationDefinition[];
@@ -116,11 +121,12 @@ export class Context {
     if (other != undefined) {
       this.document = other.document;
       this.namespace = other.namespace;
+      this.namespaces = other.namespaces;
       this.imports = other.imports;
       this.directives = other.directives;
       this.directiveMap = other.directiveMap;
       this.aliases = other.aliases;
-      this.interface = other.interface;
+      this.interfaces = other.interfaces;
       this.roles = other.roles;
       this.enums = other.enums;
       this.types = other.types;
@@ -136,11 +142,12 @@ export class Context {
         new Name(undefined, ""),
         undefined
       );
+      this.namespaces = new Array<NamespaceDefinition>();
       this.directives = new Array<DirectiveDefinition>();
       this.directiveMap = new Map<string, DirectiveDefinition>();
       this.imports = new Array<ImportDefinition>();
       this.aliases = new Array<AliasDefinition>();
-      this.interface = new InterfaceDefinition();
+      this.interfaces = new Array<InterfaceDefinition>();
       this.roles = new Array<RoleDefinition>();
       this.enums = new Array<EnumDefinition>();
       this.types = new Array<TypeDefinition>();
@@ -148,7 +155,7 @@ export class Context {
       this.annotations = new Array<Annotation>();
       this.allTypes = new Map<
         string,
-        TypeDefinition | EnumDefinition | UnionDefinition
+        TypeDefinition | EnumDefinition | UnionDefinition | AliasDefinition
       >();
 
       this.errors = new ErrorHolder();
@@ -163,9 +170,11 @@ export class Context {
   }
 
   clone({
+    namespace,
     importDef,
     directive,
     alias,
+    interfaceDef,
     role,
     type,
     operations,
@@ -184,9 +193,12 @@ export class Context {
   }: NamedParameters): Context {
     var context = new Context(this.config, undefined, this);
 
-    context.importDef = importDef || this.importDef;
+    context.namespace = namespace || this.namespace;
+    context.namespacePos = this.namespacePos;
+    context.import = importDef || this.import;
     context.directive = directive || this.directive;
     context.alias = alias || this.alias;
+    context.interface = interfaceDef || this.interface;
     context.role = role || this.role;
     context.type = type || this.type;
     context.operations = operations || this.operations;
@@ -207,10 +219,13 @@ export class Context {
   }
 
   private parseDocument(): void {
-    this.document!.definitions.forEach((value) => {
+    this.document!.definitions.forEach((value, index) => {
       switch (value.getKind()) {
         case Kind.NamespaceDefinition:
-          this.namespace = value as NamespaceDefinition;
+          const namespace = value as NamespaceDefinition;
+          this.namespaces.push(namespace);
+          this.namespace = namespace;
+          this.namespacePos = index;
           break;
         case Kind.DirectiveDefinition:
           const directive = value as DirectiveDefinition;
@@ -226,7 +241,8 @@ export class Context {
           this.allTypes.set(alias.name.value, alias);
           break;
         case Kind.InterfaceDefinition:
-          this.interface = value as InterfaceDefinition;
+          const iface = value as InterfaceDefinition;
+          this.interfaces.push(iface);
           break;
         case Kind.RoleDefinition:
           const role = value as RoleDefinition;

--- a/src/ast/visitor.ts
+++ b/src/ast/visitor.ts
@@ -328,10 +328,12 @@ export interface Visitor {
   visitTypesAfter(context: Context): void;
 
   visitEnumsBefore(context: Context): void;
+  visitEnumBefore(context: Context): void;
   visitEnum(context: Context): void;
   visitEnumValuesBefore(context: Context): void;
   visitEnumValue(context: Context): void;
   visitEnumValuesAfter(context: Context): void;
+  visitEnumAfter(context: Context): void;
   visitEnumsAfter(context: Context): void;
 
   visitUnionsBefore(context: Context): void;
@@ -652,6 +654,12 @@ export abstract class AbstractVisitor implements Visitor {
   public triggerEnumsBefore(context: Context): void {
     this.triggerCallbacks(context, "EnumsBefore");
   }
+  public visitEnumBefore(context: Context): void {
+    this.triggerEnumsBefore(context);
+  }
+  public triggerEnumBefore(context: Context): void {
+    this.triggerCallbacks(context, "EnumBefore");
+  }
   public visitEnum(context: Context): void {
     this.triggerEnum(context);
   }
@@ -675,6 +683,12 @@ export abstract class AbstractVisitor implements Visitor {
   }
   public triggerEnumValuesAfter(context: Context): void {
     this.triggerCallbacks(context, "EnumValuesAfter");
+  }
+  public visitEnumAfter(context: Context): void {
+    this.triggerEnumsAfter(context);
+  }
+  public triggerEnumAfter(context: Context): void {
+    this.triggerCallbacks(context, "EnumAfter");
   }
   public visitEnumsAfter(context: Context): void {
     this.triggerEnumsAfter(context);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -691,7 +691,7 @@ class Parser {
     }
 
     const name = new Name(this.loc(start), start.value);
-    this.expectToken(TokenKind.EQUALS)
+    this.expectToken(TokenKind.EQUALS);
     const type = this.parseType();
     const annotations = this.parseAnnotations();
     return new AliasDefinition(

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -987,7 +987,7 @@ class Parser {
     const token = this.expectToken(TokenKind.INT);
     const index = new IntValue(this.loc(token), parseInt(token.value));
     let display: StringValue | undefined;
-    if (this.peek(TokenKind.STRING)) {
+    if (this.expectOptionalKeyword("as")) {
       display = this.parseStringLiteral();
     }
 

--- a/src/rules/namespace_first.ts
+++ b/src/rules/namespace_first.ts
@@ -1,0 +1,15 @@
+import { AbstractVisitor, Context, Node } from "../ast";
+import { validationError } from "../error";
+
+export class NamespaceFirst extends AbstractVisitor {
+  visitNamespace(context: Context): void {
+    if (context.namespacePos != 0) {
+      context.reportError(
+        validationError(
+          context.namespace,
+          `namespace must be defined before any other definition`
+        )
+      );
+    }
+  }
+}

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -1,4 +1,7 @@
 import { Visitor } from "../ast";
+import { NamespaceFirst } from "./namespace_first";
+import { SingleNamespaceDefined } from "./single_namespace_defined";
+import { SingleInterfaceDefined } from "./single_interface_defined";
 //import { CamelCaseDirectiveNames } from "./camel_case_directive_names";
 import { PascalCaseTypeNames } from "./pascal_case_type_names";
 import { UniqueDirectiveNames } from "./unique_directive_names";
@@ -21,6 +24,9 @@ export interface ValidationRule {
 }
 
 export const CommonRules: Array<ValidationRule> = [
+  NamespaceFirst,
+  SingleNamespaceDefined,
+  SingleInterfaceDefined,
   //CamelCaseDirectiveNames,
   PascalCaseTypeNames,
   UniqueDirectiveNames,

--- a/src/rules/single_interface_defined.ts
+++ b/src/rules/single_interface_defined.ts
@@ -1,0 +1,16 @@
+import { AbstractVisitor, Context, Node } from "../ast";
+import { validationError } from "../error";
+
+export class SingleInterfaceDefined extends AbstractVisitor {
+  private found: boolean = false;
+
+  visitInterface(context: Context): void {
+    if (this.found) {
+      const iface = context.interface!;
+      context.reportError(
+        validationError(iface, `only one interface can be defined`)
+      );
+    }
+    this.found = true;
+  }
+}

--- a/src/rules/single_namespace_defined.ts
+++ b/src/rules/single_namespace_defined.ts
@@ -1,0 +1,16 @@
+import { AbstractVisitor, Context, Node } from "../ast";
+import { validationError } from "../error";
+
+export class SingleNamespaceDefined extends AbstractVisitor {
+  private found: boolean = false;
+
+  visitNamespace(context: Context): void {
+    if (this.found) {
+      const namespace = context.namespace;
+      context.reportError(
+        validationError(namespace, `only one namespace can be defined`)
+      );
+    }
+    this.found = true;
+  }
+}

--- a/src/rules/unique_type_field_names.ts
+++ b/src/rules/unique_type_field_names.ts
@@ -9,6 +9,7 @@ export class UniqueTypeFieldNames extends AbstractVisitor {
     this.parentName = context.type!.name.value;
     this.names = new Set<string>();
   }
+
   visitTypeField(context: Context): void {
     const field = context.field!;
     const fieldName = field.name.value;

--- a/src/rules/valid_annotation_locations.ts
+++ b/src/rules/valid_annotation_locations.ts
@@ -52,6 +52,11 @@ export class ValidAnnotationLocations extends AbstractVisitor {
     this.check(context, def.annotations, "UNION");
   }
 
+  visitAlias(context: Context): void {
+    const alias = context.alias!;
+    this.check(context, alias.annotations, "ALIAS");
+  }
+
   private check(context: Context, annotations: Annotation[], location: string) {
     for (let annotation of annotations) {
       this.checkAnnotation(context, annotations, annotation, location);
@@ -105,7 +110,10 @@ export class ValidAnnotationLocations extends AbstractVisitor {
             }
           case "INTERFACE":
             if (
-              findAnnotation(req.directive.value, context.interface.annotations)
+              findAnnotation(
+                req.directive.value,
+                context.interface!.annotations
+              )
             ) {
               found = true;
               break;
@@ -168,6 +176,14 @@ export class ValidAnnotationLocations extends AbstractVisitor {
             if (
               context.union != undefined &&
               findAnnotation(req.directive.value, context.union!.annotations)
+            ) {
+              found = true;
+              break;
+            }
+          case "ALIAS":
+            if (
+              context.alias != undefined &&
+              findAnnotation(req.directive.value, context.alias!.annotations)
             ) {
               found = true;
               break;

--- a/src/rules/valid_directive_locations.ts
+++ b/src/rules/valid_directive_locations.ts
@@ -12,6 +12,7 @@ const validLocationNames = new Set([
   "ENUM",
   "ENUM_VALUE",
   "UNION",
+  "ALIAS",
 ]);
 
 export class ValidDirectiveLocations extends AbstractVisitor {

--- a/src/rules/valid_directive_requires.ts
+++ b/src/rules/valid_directive_requires.ts
@@ -12,6 +12,7 @@ const validLocationNames = new Set([
   "ENUM",
   "ENUM_VALUE",
   "UNION",
+  "ALIAS",
 ]);
 
 export class ValidDirectiveRequires extends AbstractVisitor {


### PR DESCRIPTION
- Added rules that check:
  - Only one namespace is defined and it must be at the top of the WIDL document
  - Only one interface can be defined
  - Allow ALIAS as a directive location
- Fixed enumeration parsing of optional display string.
- Added `Annotated` interface for use in the code generator.