### PR TITLE
Adding stream keyword on unary parameters and returns

### DIFF
--- a/src/ast/kinds.ts
+++ b/src/ast/kinds.ts
@@ -23,6 +23,7 @@ export enum Kind {
   ListType = "ListType",
   MapType = "MapType",
   Optional = "Optional",
+  Stream = "Stream",
 
   // Definitions
   NamespaceDefinition = "NamespaceDefinition",

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -59,3 +59,16 @@ export class Optional extends AbstractNode implements Type {
     return this.getKind();
   }
 }
+
+export class Stream extends AbstractNode implements Type {
+  type: Type;
+
+  constructor(loc: Location | undefined, type: Type) {
+    super(Kind.Stream, loc);
+    this.type = type || null;
+  }
+
+  public string(): string {
+    return this.getKind();
+  }
+}


### PR DESCRIPTION
Adding the `stream` keyword on unary parameters and returns. When present, the type is encapsulated by the new `Stream` type. `Stream` types should only exist at the top level.

Example usage:

```GraphQL
role Streamer {
  streamOut(): stream sDAF
  streamIn{in: stream sDAF}
  streamInOut{in: stream sDAF}: stream sDAF
}
```